### PR TITLE
Tweaks to how spawned process is launched (no chdir, include environment, include args)

### DIFF
--- a/ezuri.go
+++ b/ezuri.go
@@ -40,11 +40,11 @@ var (
 	check(err)
 	tmpl.Execute(f, stubCfg)
 	os.Chdir(stubDir)
-	cmdOut, err := exec.Command("go", "build", ".").Output()
-	check(err)
+	cmdOut, err := exec.Command("go", "build", "-ldflags", `-w -s`, ".").CombinedOutput()
 	if len(cmdOut) > 0 {
-		fmt.Println(string(cmdOut))
+		fmt.Println("Output: ", string(cmdOut))
 	}
+	check(err)
 	stubBytes, err := ioutil.ReadFile("stub")
 	check(err)
 	os.Chdir("..")


### PR DESCRIPTION
I needed these changes for what I'm using this for. Not sure if they're generally useful (e.g. maybe you want to chdir to root for some reason...or maybe it should be configurable....same for the envionment) - but I felt these changes made the process run in a more "expected" way - e.g. - if I run a binary I expect it's working directory to be the current directory...and I expect arguments to work. 

Feel free to let me know if I can improve the PR or if it's not really a fit for the project that's fine too.

Example:

```
user@user:~/git/qrf/ezuri$ go build -o ezuri
user@user:~/git/qrf/ezuri$ ./ezuri 
[?] Path of file to be encrypted: ./ls
[?] Path of output (encrypted) file: ./ls.ezuri
[?] Name of the target process: ferp
[?] Encryption key (32 bits - random if empty): 
[?] Encryption IV (16 bits - random if empty): 

[!] Random encryption key (used in stub): CwTnnIq0smIu5Z1rqMbK#qM8ELEY#NlI
[!] Random encryption IV (used in stub): PvH#OCTNpa1ry29Q
[!] Generating stub...
[!] Creating final executable...
[!] All done!
user@user:~/git/qrf/ezuri$ chmod +x ls.ezuri 
user@user:~/git/qrf/ezuri$ ./ls.ezuri 
aes.go  ezuri  ezuri.go  go.mod  LICENSE  ls  ls.ezuri  README.md  stub  utils.go
user@user:~/git/qrf/ezuri$ ./ls.ezuri -lah
total 6.6M
drwxrwxr-x 5 user user 4.0K Sep 23 13:57 .
drwxrwxr-x 4 user user 4.0K Sep 23 13:30 ..
-rw-rw-r-- 1 user user  336 Sep 23 13:30 aes.go
-rwxrwxr-x 1 user user 4.0M Sep 23 13:57 ezuri
-rw-rw-r-- 1 user user 1.6K Sep 23 13:30 ezuri.go
drwxrwxr-x 8 user user 4.0K Sep 23 13:57 .git
drwxrwxr-x 3 user user 4.0K Sep 23 13:30 .github
-rw-rw-r-- 1 user user   42 Sep 23 13:30 go.mod
-rw-rw-r-- 1 user user 1.1K Sep 23 13:30 LICENSE
-rwxr-xr-x 1 user user 139K Sep 23 13:40 ls
-rwxrwxr-x 1 user user 2.4M Sep 23 13:57 ls.ezuri
-rw-rw-r-- 1 user user  811 Sep 23 13:30 README.md
drwxrwxr-x 2 user user 4.0K Sep 23 13:57 stub
-rw-rw-r-- 1 user user 1.4K Sep 23 13:30 utils.go
user@user:~/git/qrf/ezuri$ 
```